### PR TITLE
fix(ai): Alt+J opens the AI side panel when nothing is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Heading anchor links give feedback.** Clicking the link icon next to a
   heading now copies a section link and shows a checkmark, instead of appearing
   to do nothing when the heading is already at the top of the view.
+- **Alt+J opens the AI side panel.** With no text selected it now opens the
+  docked AI panel (previously it only opened the inline selection bubble); with
+  a selection it still opens selection-assist in place.
 
 ### Fixed — Click after scroll lands on the right line
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -292,6 +292,9 @@ function AppContent() {
       ["marklite:spellcheck-toggle", (e) => setSpellCheckEnabled(!!(e as CustomEvent).detail?.enabled)],
       // Opened from the title-bar settings dropdown's "More settings…" entry.
       ["marklite:open-settings", () => setShowSettings(true)],
+      // Alt+J with no selection opens the docked AI side panel. The editor's
+      // ai-assist handler decides bubble (selection) vs panel (no selection).
+      ["marklite:toggle-ai-panel", () => setShowAIPanel((v) => !v)],
     ];
     handlers.forEach(([k, h]) => window.addEventListener(k, h));
 

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -543,9 +543,22 @@ function CodeEditorImpl({
         return () => registerScroller(null);
     }, [registerScroller]);
 
-    // Let App-level surfaces (command palette) open the AI bubble.
+    // Alt+J (and the command palette's "AI assist") is selection-aware, matching
+    // the docs: with text selected it opens the inline selection-assist bubble;
+    // with no selection it opens the docked AI side panel (chat about the doc).
+    // App owns the panel's open state, so we ask it to toggle via an event.
     useEffect(() => {
-        const handler = () => { viewRef.current?.focus(); openAIBubble(); };
+        const handler = () => {
+            const view = viewRef.current;
+            if (!view) return;
+            const sel = view.state.selection.main;
+            if (sel.from !== sel.to) {
+                view.focus();
+                openAIBubble();
+            } else {
+                window.dispatchEvent(new CustomEvent("marklite:toggle-ai-panel"));
+            }
+        };
         window.addEventListener("marklite:ai-assist", handler);
         return () => window.removeEventListener("marklite:ai-assist", handler);
     }, [openAIBubble]);


### PR DESCRIPTION
## Alt+J now opens the AI side panel (when nothing is selected)

Reported after #59 merged: pressing **Alt+J** didn't open the docked AI side panel.

### Root cause
The `marklite:ai-assist` handler only ever called `openAIBubble()`, so Alt+J always opened the inline selection-assist bubble. With no selection that bubble is nearly empty (or shows an "AI isn't set up" toast), so the side panel the README documents never appeared. This was **not** a regression from #59: the handler was `openAIBubble()`-only on `main` too. The README has documented two behaviors all along:

- *AI side panel: open it from the AI button next to Export (or Alt+J).*
- *Selection assist: select text and press Alt+J to rewrite/shorten/...*

Only the selection-assist half was wired.

### Fix
Make the handler selection-aware, matching the docs:
- **Text selected** → inline selection-assist bubble (unchanged).
- **No selection** → toggle the docked AI side panel.

`App` owns the panel's open state, so the editor asks it to toggle via a `marklite:toggle-ai-panel` event (same pattern as the other cross-component events).

### Verified
- `tsc` strict + 107 tests pass.
- Headless browser: typed text (no selection), pressed Alt+J, the `role="complementary"` "AI assistant" panel opened; a second Alt+J closed it.
