### PR TITLE
fix(macos): universal .dmg + real Gatekeeper guidance (issues #94, #103)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
             echo "### Installation"
             echo "- **Windows:** \`.msi\` (recommended) or \`.exe\` (NSIS installer)"
             echo "- **Linux:** \`.deb\` or \`.AppImage\`"
-            echo "- **macOS:** \`.dmg\`"
+            echo "- **macOS:** \`.dmg\` (Apple Silicon + Intel, universal)"
             echo ""
             echo "See the [CHANGELOG](https://github.com/Razee4315/Paperling/blob/main/CHANGELOG.md) for the full history."
             echo "__PAPERLING_NOTES__"
@@ -131,8 +131,14 @@ jobs:
             args: '--target aarch64-pc-windows-msvc'
           - platform: ubuntu-24.04
             args: ''
+          # Universal macOS binary (Apple Silicon + Intel in one .dmg).
+          # macos-latest is an ARM runner; building universal-apple-darwin
+          # needs the x86_64-apple-darwin Rust target too (installed below).
+          # One universal .dmg means Intel Mac users no longer download a dmg
+          # that refuses to launch, and Apple Silicon users keep a native
+          # build. Issues #94 / #103.
           - platform: macos-latest
-            args: ''
+            args: '--target universal-apple-darwin'
 
     runs-on: ${{ matrix.platform }}
 
@@ -144,6 +150,10 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Add macOS cross-compile target
+        if: matrix.platform == 'macos-latest'
+        run: rustup target add x86_64-apple-darwin
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -52,3 +52,46 @@ jobs:
             src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
           if-no-files-found: error
           retention-days: 14
+
+  # Verifies the release.yml macOS packaging (universal Apple Silicon + Intel
+  # bundle) without cutting a release — issues #94 / #103. Produces the .dmg as
+  # a run artifact only.
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust (with Intel cross-compile target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          workspaces: './src-tauri -> target'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build universal macOS bundle
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+        run: bun run tauri build --target universal-apple-darwin
+
+      - name: Upload macOS bundle as run artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: paperling-macos-universal-test
+          path: |
+            src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+          if-no-files-found: error
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -141,13 +141,24 @@ Download the latest release from the [Releases](https://github.com/Razee4315/Pap
 | Platform    | Formats                                    |
 | ----------- | ------------------------------------------ |
 | **Windows** | `.msi` installer · `.exe` (NSIS) installer |
-| **macOS**   | `.dmg` (Apple Silicon)                     |
+| **macOS**   | `.dmg` (Apple Silicon + Intel, universal)  |
 | **Linux**   | `.AppImage` · `.deb` · `.rpm`              |
 
 > **Note:** builds aren't code-signed yet, so Windows SmartScreen or macOS
-> Gatekeeper may warn on first launch. On Windows choose _More info → Run anyway_;
-> on macOS right-click the app and choose _Open_. Auto-update packages are signed
-> and verified before installing.
+> Gatekeeper may warn on first launch. On Windows choose _More info → Run anyway_.
+>
+> **macOS:** recent macOS versions report an unsigned app as _"damaged and
+> can't be opened"_ — right-click → _Open_ does **not** clear that message.
+> After copying the app to `/Applications`, run this once in Terminal and it
+> opens normally:
+>
+> ```sh
+> xattr -cr /Applications/Paperling.app
+> ```
+>
+> (Alternatively: System Settings → Privacy & Security → _Open Anyway_.) This
+> is a consequence of shipping without Apple's paid notarization, not a broken
+> download. Auto-update packages are signed and verified before installing.
 
 ## Development
 


### PR DESCRIPTION
## Summary

Addresses #94 and #103 ("app is damaged" on macOS):

- **Universal macOS build**: `release.yml` now builds `universal-apple-darwin` - one `.dmg` that is native on both Apple Silicon and Intel. Previously only an Apple Silicon dmg was produced, so Intel Mac users downloaded a dmg that could not launch.
- **Honest Gatekeeper guidance in the README**: recent macOS reports unsigned apps as *"damaged and can't be opened"*, and right-click -> Open no longer clears it (that advice was in the README and does not work). Replaced with the actual working fix: `xattr -cr /Applications/Paperling.app` (or Privacy & Security -> Open Anyway), plus the explanation that this is expected for non-notarized apps, not a broken download.
- **test-build.yml gains a `build-macos` job** that produces the universal `.dmg` as a run-only artifact, so the exact release packaging can be verified on a branch without cutting a public release. This PR's macOS job is (or will be) dispatched as its verification.

## The honest limit

A fully code-signed + notarized app (no Terminal command needed at all) requires an Apple Developer Program identity (USD 99/yr) - a purchasing decision, not a code change. Until then the universal dmg + documented workaround is the practical fix.

Closes #94
Closes #103