### PR TITLE
feat(packaging): portable Windows zip for Scoop (issue #48)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,3 +187,17 @@ jobs:
           releaseDraft: false
           prerelease: false
           includeUpdaterJson: true
+
+      - name: Package portable zip (Scoop)
+        # Portable zip of the unpacked app for Scoop and direct download
+        # (issue #48). Only the x64 Windows leg — that's what Scoop targets.
+        if: matrix.args == '--target x86_64-pc-windows-msvc'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check-and-bump.outputs.version }}
+        shell: pwsh
+        run: |
+          pwsh scripts/make-portable-zip.ps1 `
+            -ExeDir "src-tauri/target/x86_64-pc-windows-msvc/release" `
+            -OutFile "dist/Paperling_${env:VERSION}_x64-portable.zip"
+          gh release upload "v${env:VERSION}" "dist/Paperling_${env:VERSION}_x64-portable.zip" --clobber

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -43,6 +43,12 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
         run: bun run tauri build --target x86_64-pc-windows-msvc
 
+      - name: Package portable zip (verification for issue #48)
+        shell: pwsh
+        run: pwsh scripts/make-portable-zip.ps1 `
+          -ExeDir "src-tauri/target/x86_64-pc-windows-msvc/release" `
+          -OutFile "dist/Paperling-portable-test.zip"
+
       - name: Upload installers as run artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -50,5 +56,6 @@ jobs:
           path: |
             src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi
             src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
+            dist/Paperling-portable-test.zip
           if-no-files-found: error
           retention-days: 14

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -49,26 +49,20 @@ wingetcreate update Razee4315.Paperling -u "https://github.com/Razee4315/Paperli
 
 ---
 
-## 2. Scoop (Windows) — experimental ⚠️
+## 2. Scoop (Windows)
 
 File: [`scoop/paperling.json`](./scoop/paperling.json).
 
-Scoop prefers *portable* apps, but Paperling currently ships only an NSIS
-installer. This manifest uses Scoop's `#/dl.7z` trick to extract the installer
-with 7-Zip. **Test it before publishing** — depending on the NSIS layout the
-`bin` / `extract_dir` may need adjusting:
-
-```powershell
-scoop install ./packaging/scoop/paperling.json
-```
+Releases now include a **portable zip** — `Paperling_<version>_x64-portable.zip`,
+built by `scripts/make-portable-zip.ps1` in `release.yml` (the unpacked
+`Paperling.exe` plus any runtime DLLs). The manifest's pinned version still
+points at the legacy NSIS-installer extraction (the `#/dl.7z` trick) because a
+hash can only be pinned for an existing file; `autoupdate` points at the
+portable zip, so every new release installs the clean portable way — no
+extraction hacks — which makes it eligible for the Scoop `extras` bucket.
 
 To publish: create a bucket repo (e.g. `Razee4315/scoop-bucket`), drop the JSON
 in, then `scoop bucket add paperling https://github.com/Razee4315/scoop-bucket`.
-
-**Cleaner long-term fix:** add a portable `.zip` artifact to the release (zip the
-unpacked `Paperling.exe` + resources). Then the Scoop manifest points straight at
-the zip — no extraction hacks — and it's eligible for the official `extras`
-bucket.
 
 ---
 

--- a/packaging/scoop/paperling.json
+++ b/packaging/scoop/paperling.json
@@ -3,7 +3,10 @@
   "description": "A minimal, distraction-free Markdown editor with live preview, math, diagrams, and an optional AI assistant.",
   "homepage": "https://github.com/Razee4315/Paperling",
   "license": "Freeware",
-  "notes": "Paperling is free for personal use. Commercial use requires permission from the author.",
+  "notes": [
+    "Paperling is free for personal use. Commercial use requires permission from the author.",
+    "Releases from v1.0.51 on ship a portable zip; this manifest auto-updates to it."
+  ],
   "architecture": {
     "64bit": {
       "url": "https://github.com/Razee4315/Paperling/releases/download/v0.6.21/Paperling_0.6.21_x64-setup.exe#/dl.7z",
@@ -18,7 +21,7 @@
   "autoupdate": {
     "architecture": {
       "64bit": {
-        "url": "https://github.com/Razee4315/Paperling/releases/download/v$version/Paperling_$version_x64-setup.exe#/dl.7z"
+        "url": "https://github.com/Razee4315/Paperling/releases/download/v$version/Paperling_$version_x64-portable.zip"
       }
     }
   }

--- a/scripts/make-portable-zip.ps1
+++ b/scripts/make-portable-zip.ps1
@@ -1,0 +1,38 @@
+# Builds the portable Windows zip for Scoop (issue #48): the unpacked
+# Paperling.exe plus any runtime DLLs the Tauri build dropped next to it,
+# zipped as Paperling_<version>_x64-portable.zip.
+#
+# Usage: pwsh scripts/make-portable-zip.ps1 -ExeDir <path> -OutFile <zip path>
+#   -ExeDir   the directory containing the built Paperling.exe, e.g.
+#             src-tauri/target/x86_64-pc-windows-msvc/release
+#   -OutFile  destination zip, e.g. dist/Paperling_1.0.50_x64-portable.zip
+param(
+    [Parameter(Mandatory = $true)][string]$ExeDir,
+    [Parameter(Mandatory = $true)][string]$OutFile
+)
+
+$ErrorActionPreference = "Stop"
+
+$exe = Join-Path $ExeDir "Paperling.exe"
+if (-not (Test-Path $exe)) {
+    throw "Paperling.exe not found in $ExeDir"
+}
+
+$staging = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "paperling-portable-$(Guid::NewGuid().ToString('N'))") -Force
+try {
+    # The exe is self-contained for daily use (WebView2 ships with Windows);
+    # any runtime DLLs the build emitted go along for the ride, just in case.
+    Copy-Item $exe $staging.FullName
+    Get-ChildItem $ExeDir -Filter "*.dll" | ForEach-Object {
+        Copy-Item $_.FullName $staging.FullName
+    }
+
+    $outDir = Split-Path $OutFile -Parent
+    if ($outDir) { New-Item -ItemType Directory -Path $outDir -Force | Out-Null }
+    Compress-Archive -Path (Join-Path $staging.FullName "*") -DestinationPath $OutFile -Force
+
+    $zip = Get-Item $OutFile
+    Write-Host "Portable zip created: $($zip.FullName) ($([math]::Round($zip.Length / 1MB, 1)) MB)"
+} finally {
+    Remove-Item $staging.FullName -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/make-portable-zip.ps1
+++ b/scripts/make-portable-zip.ps1
@@ -18,7 +18,8 @@ if (-not (Test-Path $exe)) {
     throw "Paperling.exe not found in $ExeDir"
 }
 
-$staging = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "paperling-portable-$(Guid::NewGuid().ToString('N'))") -Force
+$stagingName = "paperling-portable-" + [guid]::NewGuid().ToString('N')
+$staging = New-Item -ItemType Directory -Path (Join-Path $env:TEMP $stagingName) -Force
 try {
     # The exe is self-contained for daily use (WebView2 ships with Windows);
     # any runtime DLLs the build emitted go along for the ride, just in case.


### PR DESCRIPTION
## Summary

Implements #48:

- **`scripts/make-portable-zip.ps1`** zips the unpacked `Paperling.exe` (+ runtime DLLs) into `Paperling_<version>_x64-portable.zip`.
- **`release.yml`** runs it on the x64 Windows leg and attaches the zip to the GitHub release (`gh release upload`).
- **`packaging/scoop/paperling.json`**: `autoupdate` now points at the portable zip - the `#/dl.7z` NSIS-extraction hack is gone from all future updates, which is what first-class Scoop support (and the `extras` bucket) requires. The pinned legacy `0.6.21` entry keeps its URL+hash (a hash can only be pinned for an existing file); the first release cut after this merge upgrades scoop users to the portable zip automatically.
- **`test-build.yml`** (Windows job) runs the same packaging step and uploads the zip as a run artifact - dispatched on this branch as verification, so the packaging is proven without cutting a public release.

Closes #48